### PR TITLE
WIP add create_role var

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module "aws_iam_dest_user_group_role" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| create\_circleci\_role | Create IAM role for CircleCI user to assume. | bool | `"false"` | no |
+| create\_role | Create this IAM role. | bool | `"true"` | no |
 | iam\_role\_name | The name for the created role. Conceptually, this should correspond to a group. | string | n/a | yes |
 | source\_account\_id | The account id that the assume role call will be coming from. | string | n/a | yes |
 | source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "aws_iam_dest_user_group_role" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| create\_circleci\_role | Create IAM role for CircleCI user to assume. | bool | `"false"` | no |
 | iam\_role\_name | The name for the created role. Conceptually, this should correspond to a group. | string | n/a | yes |
 | source\_account\_id | The account id that the assume role call will be coming from. | string | n/a | yes |
 | source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
 }
 
 resource "aws_iam_role" "main" {
-  count              = var.create_circleci_role ? 1 : 0
+  count              = var.create_role ? 1 : 0
   name               = var.iam_role_name
   description        = "Cross-account role for ${var.iam_role_name}"
   assume_role_policy = data.aws_iam_policy_document.role_assume_role_policy.json

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
 }
 
 resource "aws_iam_role" "main" {
+  count              = var.create_circleci_role ? 1 : 0
   name               = var.iam_role_name
   description        = "Cross-account role for ${var.iam_role_name}"
   assume_role_policy = data.aws_iam_policy_document.role_assume_role_policy.json

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,9 @@ variable "source_account_role_names" {
   description = "The name of the role that the assume role call will be coming from. Again, this should correspond to a group."
   type        = list
 }
+
+variable "create_circleci_role" {
+  description = "Create IAM role for CircleCI user to assume."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,8 @@ variable "source_account_role_names" {
   type        = list
 }
 
-variable "create_circleci_role" {
-  description = "Create IAM role for CircleCI user to assume."
+variable "create_role" {
+  description = "Create this IAM role."
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
This would add a variable (default to true so not a breaking change) that allows users to indicate whether to create a resource in the module or not. That may sound like it makes no sense, but it allows the module to be used in scenarios where you want to create some but not all roles in a module of these modules. Specifically to be used in conjunction currently here: https://github.com/trussworks/legendary-waddle/tree/master/modules/iam-cross-account-access
We're testing whether this is the best way to go about doing this, so do not merge.