### PR TITLE
make mfa conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ module "aws_iam_dest_user_group_role" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | iam\_role\_name | The name for the created role. Conceptually, this should correspond to a group. | string | n/a | yes |
+| mfa\_present | Whether the created policy will include MFA. | string | `"true"` | no |
 | source\_account\_id | The account id that the assume role call will be coming from. | string | n/a | yes |
 | source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module "aws_iam_dest_user_group_role" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | iam\_role\_name | The name for the created role. Conceptually, this should correspond to a group. | string | n/a | yes |
-| mfa\_present | Whether the created policy will include MFA. | string | `"true"` | no |
+| require\_mfa | Whether the created policy will include MFA. | bool | `"true"` | no |
 | source\_account\_id | The account id that the assume role call will be coming from. | string | n/a | yes |
 | source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This module creates a role based on the "iam_role_name" variable that can be ass
 
 The role in the source account must exist before creating this resource. This module should be paried with the iam-cross-acct-src module to create a role in the source account with permissions to assume the role created in this module.
 
-The source assume role call must be authenticated with MFA.
+The source assume role call defaults to requiring MFA.
 
 _Philosophical note_: There should be a single account in your AWS organization that manages users and groups. In that account, there will be a 1:1 mapping to a group and a role. That role may have AssumeRole permissions to multiple other roles across the accounts in the AWS organization.
 The role defined in this module should be one of those roles that can be assumed by the role in the original user management account.

--- a/main.tf
+++ b/main.tf
@@ -7,11 +7,11 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
       identifiers = "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}"
     }
 
-    # only allow folks with MFA
+    # MFA conditional--defaults to true
     condition {
       test     = "Bool"
       variable = "aws:MultiFactorAuthPresent"
-      values   = ["true"]
+      values   = [var.mfa_present]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -7,11 +7,11 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
       identifiers = "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}"
     }
 
-    # MFA conditional--defaults to true
+    # Conditionally require MFA (defaults to true)
     condition {
       test     = "Bool"
       variable = "aws:MultiFactorAuthPresent"
-      values   = [var.mfa_present]
+      values   = [tostring(var.require_mfa)]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,9 @@ variable "source_account_role_names" {
   description = "The name of the role that the assume role call will be coming from. Again, this should correspond to a group."
   type        = list
 }
+
+variable "mfa_present" {
+  description = "Whether the created policy will include MFA."
+  type        = string
+  default     = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,8 @@ variable "source_account_role_names" {
   type        = list
 }
 
-variable "mfa_present" {
+variable "require_mfa" {
   description = "Whether the created policy will include MFA."
-  type        = string
-  default     = "true"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
When using this module for a robot user such as CircleCI, you can't have MFA required. Here we've made this a conditional.
It should not have an impact on any of the current uses of the module because it defaults to true.