### PR TITLE
Allow trusted relationship to be account level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:tf12-4c1fd54273446484259597ae3da9deb2806498ed
+      - image: trussworks/circleci-docker-primary:tf12-4d635dae28eaccd4486a91b93ae57d35f73de536
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This module creates a role based on the "iam_role_name" variable that can be assumed by the roles listed in "source_account_role_names" from the account id defined in the "source_account_id" variable.
 
-The role in the source account must exist before creating this resource. This module should be paried with the iam-cross-acct-src module to create a role in the source account with permissions to assume the role created in this module.
+The role in the source account must exist before creating this resource. This module should be paired with the iam-cross-acct-src module to create a role in the source account with permissions to assume the role created in this module. In certain cases, the trusted relationship between source and destination may be account-based rather than role based.
 
 The source assume role call must be authenticated with MFA.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module "aws_iam_dest_user_group_role" {
 |------|-------------|:----:|:-----:|:-----:|
 | iam\_role\_name | The name for the created role. Conceptually, this should correspond to a group. | string | n/a | yes |
 | source\_account\_id | The account id that the assume role call will be coming from. | string | n/a | yes |
-| source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | `""` | no |
+| source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module "aws_iam_dest_user_group_role" {
 |------|-------------|:----:|:-----:|:-----:|
 | iam\_role\_name | The name for the created role. Conceptually, this should correspond to a group. | string | n/a | yes |
 | source\_account\_id | The account id that the assume role call will be coming from. | string | n/a | yes |
-| source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | n/a | yes |
+| source\_account\_role\_names | The name of the role that the assume role call will be coming from. Again, this should correspond to a group. | list | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,10 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]
 
+    # can either trust account or specific roles in the account
     principals {
       type        = "AWS"
-      identifiers = "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}"
+      identifiers = var.source_account_role_names ? "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}" : ["${format("arn:aws:iam::%s:root", var.source_account_id)}"]
     }
 
     # only allow folks with MFA

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
     # can either trust account or specific roles in the account
     principals {
       type        = "AWS"
-      identifiers = length(var.source_account_role_names) > 0  ? "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}" : ["${format("arn:aws:iam::%s:root", var.source_account_id)}"]
+      identifiers = length(var.source_account_role_names) > 0 ? "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}" : ["${format("arn:aws:iam::%s:root", var.source_account_id)}"]
     }
 
     # only allow folks with MFA

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
     # can either trust account or specific roles in the account
     principals {
       type        = "AWS"
-      identifiers = var.source_account_role_names != "" ? "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}" : ["${format("arn:aws:iam::%s:root", var.source_account_id)}"]
+      identifiers = length(var.source_account_role_names) > 0  ? "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}" : ["${format("arn:aws:iam::%s:root", var.source_account_id)}"]
     }
 
     # only allow folks with MFA

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
     # can either trust account or specific roles in the account
     principals {
       type        = "AWS"
-      identifiers = var.source_account_role_names ? "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}" : ["${format("arn:aws:iam::%s:root", var.source_account_id)}"]
+      identifiers = var.source_account_role_names != "" ? "${formatlist(format("arn:aws:iam::%s:role/%%s", var.source_account_id), var.source_account_role_names)}" : ["${format("arn:aws:iam::%s:root", var.source_account_id)}"]
     }
 
     # only allow folks with MFA

--- a/variables.tf
+++ b/variables.tf
@@ -11,4 +11,5 @@ variable "source_account_id" {
 variable "source_account_role_names" {
   description = "The name of the role that the assume role call will be coming from. Again, this should correspond to a group."
   type        = list
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,5 +11,5 @@ variable "source_account_id" {
 variable "source_account_role_names" {
   description = "The name of the role that the assume role call will be coming from. Again, this should correspond to a group."
   type        = list
-  default     = ""
+  default     = []
 }


### PR DESCRIPTION
While working on this: https://www.pivotaltracker.com/story/show/169169473
We found that the way this was set up required two role assumptions to use with CircleCI robot. We decided to simplify by making it possible to use the module to create a policy with a trusted relationship with either an account or a role in the account. The way it's done here, you can still limit on account and role, but there's the potential to limit just on the account.