### PR TITLE
Making the default case more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module "aws_iam_dest_user_group_role" {
 }
 ```
 
-However, if you want to make the dependency on the source role explicit, you can do it by adding the `source_account_role_names` parameter, like the following example:
+However, if you want to make the dependency on the source role explicit, you can do it by adding the `source_account_role_names` parameter, like the following example. This uses [IAM role chaining](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html), which institutes a number of restrictions; see the docs for more information.
 
 ```hcl
 module "aws_iam_dest_user_group_role" {

--- a/README.md
+++ b/README.md
@@ -10,10 +10,24 @@ Generally speaking, the role defined in this module should also map 1:1 to that 
 
 ## Usage
 
+In most cases, you will just use the `source_account_id` parameter to trust the user and group managment account; you can then keep all management of which of those users and groups can assume roles there. The following code illustrates that pattern:
+
+```hcl
+module "aws_iam_dest_user_group_role" {
+  source  = "trussworks/iam-cross-acct-dest/aws"
+  version = "1.0.3"
+
+  iam_role_name     = "group-name"
+  source_account_id = "account-id"
+}
+```
+
+However, if you want to make the dependency on the source role explicit, you can do it by adding the `source_account_role_names` parameter, like the following example:
+
 ```hcl
 module "aws_iam_dest_user_group_role" {
   source = "trussworks/iam-cross-acct-dest/aws"
-  version = "1.0.0"
+  version = "1.0.3"
   iam_role_name = "group-name"
   source_account_id = "account-id"
   source_account_role_names = ["group-name"]


### PR DESCRIPTION
I ran into some confusion looking at this module when I was writing the org bootstrapping guide because the default example used the `source_account_role_names` parameter which we don't actually use in our general pattern (instead just trusting the `id` account to handle this correctly). I've removed it from the default example and added some explanatory text. I'm not sure if this is too wordy now -- maybe we don't need the full second example if we explain the default case?