### PR TITLE
remove role-chaining example/reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ module "aws_iam_dest_user_group_role" {
   source_account_id = "account-id"
 }
 
+```
+
+However, if you want to make the dependency on the source role explicit, you can do it by adding the `source_account_role_names` parameter, like the following example. This uses [IAM role chaining](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html), which is not a recommended method as it institutes a number of restrictions; see the docs for more information.
+
+```hcl
+module "aws_iam_dest_user_group_role" {
+  source = "trussworks/iam-cross-acct-dest/aws"
+  version = "1.0.3"
+  iam_role_name = "group-name"
+  source_account_id = "account-id"
+  source_account_role_names = ["group-name"]
+}
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -22,19 +22,6 @@ module "aws_iam_dest_user_group_role" {
   iam_role_name     = "group-name"
   source_account_id = "account-id"
 }
-```
-
-However, if you want to make the dependency on the source role explicit, you can do it by adding the `source_account_role_names` parameter, like the following example. This uses [IAM role chaining](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html), which institutes a number of restrictions; see the docs for more information.
-
-```hcl
-module "aws_iam_dest_user_group_role" {
-  source = "trussworks/iam-cross-acct-dest/aws"
-  version = "1.0.3"
-  iam_role_name = "group-name"
-  source_account_id = "account-id"
-  source_account_role_names = ["group-name"]
-}
-```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/172628308)

This just removes a role-chaining reference, which we no longer recommend.